### PR TITLE
Removed ref to initcontainer as it's not used

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,13 +18,10 @@ CREDENITALS_SUFFIX ?= -aws-credentials
 
 MAIN_IMAGE_URI ?= quay.io/jupierce/openshift-python-monitoring
 IMAGE_VERSION ?= stable
-INIT_IMAGE_URI ?= quay.io/redhat/managed-prometheus-exporter-initcontainer
-INIT_IMAGE_VERSION ?= v1903.0.1
 
 # Generate variables
 
 MAIN_IMAGE ?= $(MAIN_IMAGE_URI):$(IMAGE_VERSION)
-INIT_IMAGE ?= $(INIT_IMAGE_URI):$(INIT_IMAGE_VERSION)
 
 PREFIXED_NAME ?= $(NAME_PREFIX)$(EXPORTER_NAME)
 


### PR DESCRIPTION
I'm sure this followed a pattern based on the other exporters, but it doesn't use the initcontainer so shouldn't have a reference to it.  This will get stale unless needlessly updated..

@lisa FYI