### PR TITLE
Use apps/v1 for sre-dns-latency-exporter DaemonSet

### DIFF
--- a/hack/00-osd-managed-prometheus-exporter-dns.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-prometheus-exporter-dns.selectorsyncset.yaml.tmpl
@@ -32,7 +32,7 @@ objects:
       metadata:
         name: sre-dns-latency-exporter
         namespace: openshift-monitoring
-    - apiVersion: extensions/v1beta1
+    - apiVersion: apps/v1
       kind: DaemonSet
       metadata:
         labels:

--- a/resources/040_daemonset.yaml.tmpl
+++ b/resources/040_daemonset.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: $PREFIXED_NAME
@@ -52,4 +52,3 @@ spec:
       - name: monitor-volume
         configMap:
           name: $SOURCE_CONFIGMAP_NAME
-


### PR DESCRIPTION
Was seeing issues with the sre-dns-latency-exporter DaemonSet in my test cluster.

Identified that Pods were not picking up changes to the DaemonSet when the service account token was changing.

Pulling on the thread further, the update strategy for the DaemonSet was `OnDelete`, so the pods were never getting changes. The cause for this is targeting `extensions/v1beta1` (the deprecated api version) as opposed to the proper `apps/v1` apiVersion.

After updating this to `apps/v1`, the default update strategy is now `rollingUpdate`.

/assign @rafael-azevedo @jewzaam 