### PR TITLE
Import traceback to prevent pods crash looping with tracebacks

### DIFF
--- a/hack/00-osd-managed-prometheus-exporter-dns.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-prometheus-exporter-dns.selectorsyncset.yaml.tmpl
@@ -112,7 +112,7 @@ objects:
     - apiVersion: v1
       data:
         main.py: "#!/usr/bin/python\n\nimport time\nimport logging\nfrom prometheus_client
-          import start_http_server, Counter, Gauge\nimport timeit\n\nMONITOR_NAME
+          import start_http_server, Counter, Gauge\nimport timeit\nimport traceback\n\nMONITOR_NAME
           = 'DNS'\nHOST = 'redhat.com'\n\nDNS_LATENCY = Gauge('dns_latency_milliseconds',
           'Time spent during dns request')\nDNS_ERROR = Counter('dns_failure_failure_total',
           'The total number of failures encountered resolving dns')\n\ndef run_test():\n

--- a/monitor/main.py
+++ b/monitor/main.py
@@ -4,6 +4,7 @@ import time
 import logging
 from prometheus_client import start_http_server, Counter, Gauge
 import timeit
+import traceback
 
 MONITOR_NAME = 'DNS'
 HOST = 'redhat.com'


### PR DESCRIPTION
currently the pods will crash loop over and over instead of behaving gracefully.

```
Traceback (most recent call last):
  File "/monitor/main.py", line 30, in <module>
    run_test()
  File "/monitor/main.py", line 19, in run_test
    traceback.print_exc()
NameError: global name 'traceback' is not defined
```

Import traceback so the script can continue running