### PR TITLE
Adds a toleration of all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ deploy/060_servicemonitor.yaml: resources/060_servicemonitor.yaml.tmpl
 
 .PHONY: generate-syncset
 generate-syncset:
-	docker run --rm -v `pwd`:`pwd` python:2.7.15 /bin/sh -c "cd `pwd`; pip install pyyaml; scripts/generate_syncset.py -t ${SELECTOR_SYNC_SET_TEMPLATE_DIR} -y ${YAML_DIRECTORY} -d ${SELECTOR_SYNC_SET_DESTINATION} -r ${REPO_NAME}"
+	docker run --rm -v `pwd`:`pwd` quay.io/kbater/python:2.7.15 /bin/sh -c "cd `pwd`; pip install pyyaml; scripts/generate_syncset.py -t ${SELECTOR_SYNC_SET_TEMPLATE_DIR} -y ${YAML_DIRECTORY} -d ${SELECTOR_SYNC_SET_DESTINATION} -r ${REPO_NAME}"
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,8 @@ deploy/060_servicemonitor.yaml: resources/060_servicemonitor.yaml.tmpl
 
 .PHONY: generate-syncset
 generate-syncset:
-	docker run --rm -v `pwd`:`pwd` quay.io/kbater/python:2.7.15 /bin/sh -c "cd `pwd`; pip install pyyaml; scripts/generate_syncset.py -t ${SELECTOR_SYNC_SET_TEMPLATE_DIR} -y ${YAML_DIRECTORY} -d ${SELECTOR_SYNC_SET_DESTINATION} -r ${REPO_NAME}"
+	docker pull quay.io/app-sre/python:2 && docker tag quay.io/app-sre/python:2 python:2 || true; \
+	docker run --rm -v `pwd`:`pwd` python:2 /bin/sh -c "cd `pwd`; pip install pyyaml; scripts/generate_syncset.py -t ${SELECTOR_SYNC_SET_TEMPLATE_DIR} -y ${YAML_DIRECTORY} -d ${SELECTOR_SYNC_SET_DESTINATION} -r ${REPO_NAME}"
 
 .PHONY: clean
 clean:

--- a/hack/00-osd-managed-prometheus-exporter-dns.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-prometheus-exporter-dns.selectorsyncset.yaml.tmpl
@@ -84,6 +84,8 @@ objects:
             dnsPolicy: ClusterFirst
             restartPolicy: Always
             serviceAccountName: sre-dns-latency-exporter
+            tolerations:
+            - operator: Exists
             volumes:
             - configMap:
                 name: sre-dns-latency-exporter-code

--- a/resources/040_daemonset.yaml.tmpl
+++ b/resources/040_daemonset.yaml.tmpl
@@ -48,6 +48,8 @@ spec:
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       serviceAccountName: $SERVICEACCOUNT_NAME
+      tolerations:
+      - operator: Exists
       volumes:
       - name: monitor-volume
         configMap:


### PR DESCRIPTION
This basically adds a wildcard toleration so that when node labels or
taints change on nodes this daemonset will still be scheduled
appropriately.

If we need this to only run on specific nodes (i.e. We don't want these
on masters, but only on infra/workers, or we only want these on workers)
let me know and I can add the appropriate node selector(s).