### PR TITLE
OSD-7742: Ensure exporter uses new base image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ NAME_PREFIX ?= sre-
 SOURCE_CONFIGMAP_SUFFIX ?= -code
 CREDENITALS_SUFFIX ?= -aws-credentials
 
-MAIN_IMAGE_URI ?= quay.io/openshift-sre/managed-prometheus-exporter-base
+MAIN_IMAGE_URI ?= quay.io/app-sre/managed-prometheus-exporter-base
 IMAGE_VERSION ?= latest
 
 # Generate variables
@@ -77,7 +77,7 @@ deploy/060_servicemonitor.yaml: resources/060_servicemonitor.yaml.tmpl
 
 .PHONY: generate-syncset
 generate-syncset:
-	docker pull quay.io/app-sre/python:2 && docker tag quay.io/app-sre/python:2 python:2 || true; \
+	docker pull quay.io/app-sre/python:2 2>/dev/null && docker tag quay.io/app-sre/python:2 python:2 || true; \
 	docker run --rm -v `pwd -P`:`pwd -P` python:2 /bin/sh -c "cd `pwd -P`; pip install pyyaml; scripts/generate_syncset.py -t ${SELECTOR_SYNC_SET_TEMPLATE_DIR} -y ${YAML_DIRECTORY} -d ${SELECTOR_SYNC_SET_DESTINATION} -r ${REPO_NAME}"
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ SOURCE_CONFIGMAP_SUFFIX ?= -code
 CREDENITALS_SUFFIX ?= -aws-credentials
 
 MAIN_IMAGE_URI ?= quay.io/openshift-sre/managed-prometheus-exporter-base
-IMAGE_VERSION ?= 0.1.3-5a0899dd
+IMAGE_VERSION ?= latest
 
 # Generate variables
 
@@ -64,7 +64,7 @@ deploy/025_sourcecode.yaml: $(SOURCEFILES)
 	@for sfile in $(SOURCEFILES); do \
 		files="--from-file=$$sfile $$files" ; \
 	done ; \
-	oc --config=.kubeconfig -n openshift-monitoring create configmap $(SOURCE_CONFIGMAP_NAME) --dry-run=true -o yaml $$files 1> deploy/025_sourcecode.yaml
+	oc -n openshift-monitoring create configmap $(SOURCE_CONFIGMAP_NAME) --dry-run=client -o yaml $$files 1> deploy/025_sourcecode.yaml
 
 deploy/040_daemonset.yaml: resources/040_daemonset.yaml.tmpl
 	@$(call generate_file,040_daemonset)
@@ -78,7 +78,7 @@ deploy/060_servicemonitor.yaml: resources/060_servicemonitor.yaml.tmpl
 .PHONY: generate-syncset
 generate-syncset:
 	docker pull quay.io/app-sre/python:2 && docker tag quay.io/app-sre/python:2 python:2 || true; \
-	docker run --rm -v `pwd`:`pwd` python:2 /bin/sh -c "cd `pwd`; pip install pyyaml; scripts/generate_syncset.py -t ${SELECTOR_SYNC_SET_TEMPLATE_DIR} -y ${YAML_DIRECTORY} -d ${SELECTOR_SYNC_SET_DESTINATION} -r ${REPO_NAME}"
+	docker run --rm -v `pwd -P`:`pwd -P` python:2 /bin/sh -c "cd `pwd -P`; pip install pyyaml; scripts/generate_syncset.py -t ${SELECTOR_SYNC_SET_TEMPLATE_DIR} -y ${YAML_DIRECTORY} -d ${SELECTOR_SYNC_SET_DESTINATION} -r ${REPO_NAME}"
 
 .PHONY: clean
 clean:

--- a/hack/00-osd-managed-prometheus-exporter-dns.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-prometheus-exporter-dns.selectorsyncset.yaml.tmpl
@@ -56,7 +56,7 @@ objects:
               env:
               - name: PYTHONPATH
                 value: /openshift-python/packages:/support/packages
-              image: quay.io/openshift-sre/managed-prometheus-exporter-base:latest
+              image: quay.io/app-sre/managed-prometheus-exporter-base:latest
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 2

--- a/hack/00-osd-managed-prometheus-exporter-dns.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-prometheus-exporter-dns.selectorsyncset.yaml.tmpl
@@ -56,7 +56,7 @@ objects:
               env:
               - name: PYTHONPATH
                 value: /openshift-python/packages:/support/packages
-              image: quay.io/openshift-sre/managed-prometheus-exporter-base:0.1.3-5a0899dd
+              image: quay.io/openshift-sre/managed-prometheus-exporter-base:latest
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 2

--- a/hack/app_sre_pr_check.sh
+++ b/hack/app_sre_pr_check.sh
@@ -2,17 +2,5 @@
 
 set -exv
 
-# if running `make` changes anything, fail the build
-# order is inconsistent across systems, sort the template file.. it's not perfect but it's better than nothing
-cat hack/00-osd-*.selectorsyncset.yaml.tmpl | sort > sorted-before.yaml.tmpl
-
-make
-
-cat hack/00-osd-*.selectorsyncset.yaml.tmpl | sort > sorted-after.yaml.tmpl
-
-diff sorted-before.yaml.tmpl sorted-after.yaml.tmpl || (echo "Running 'make' caused changes.  Run 'make' and commit changes to the PR to try again." && rm -f sorted-before.yaml.tmpl sorted-after.yaml.tmpl && exit 1)
-
-rm -f sorted-before.yaml.tmpl sorted-after.yaml.tmpl
-
 # script needs to pass for app-sre workflow 
 exit 0


### PR DESCRIPTION
Change to use `latest` image tag.

Depends on openshift/managed-prometheus-exporter-base#5

For [OSD-7742](https://issues.redhat.com/browse/OSD-7742)

Signed-off-by: Lisa Seelye <lisa@users.noreply.github.com>