### PR TITLE
OSD-9058 Enable exporter to trust user-ca-bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ RESOURCELIST := servicemonitor/$(PREFIXED_NAME) service/$(PREFIXED_NAME) \
 	rolebinding/$(PREFIXED_NAME) serviceaccount/$(SERVICEACCOUNT_NAME) \
 	clusterrole/sre-allow-read-cluster-setup
 
-all: deploy/010_serviceaccount-rolebinding.yaml deploy/025_sourcecode.yaml deploy/040_daemonset.yaml deploy/050_service.yaml deploy/060_servicemonitor.yaml generate-syncset
+all: deploy/010_serviceaccount-rolebinding.yaml deploy/025_sourcecode.yaml deploy/030_ca-configmap.yaml deploy/040_daemonset.yaml deploy/050_service.yaml deploy/060_servicemonitor.yaml generate-syncset
 
 deploy/010_serviceaccount-rolebinding.yaml: resources/010_serviceaccount-rolebinding.yaml.tmpl
 	@$(call generate_file,010_serviceaccount-rolebinding)
@@ -65,6 +65,9 @@ deploy/025_sourcecode.yaml: $(SOURCEFILES)
 		files="--from-file=$$sfile $$files" ; \
 	done ; \
 	oc -n openshift-monitoring create configmap $(SOURCE_CONFIGMAP_NAME) --dry-run=client -o yaml $$files 1> deploy/025_sourcecode.yaml
+
+deploy/030_ca-configmap.yaml: resources/030_ca-configmap.yaml.tmpl
+	@$(call generate_file,030_ca-configmap)
 
 deploy/040_daemonset.yaml: resources/040_daemonset.yaml.tmpl
 	@$(call generate_file,040_daemonset)

--- a/hack/00-osd-managed-prometheus-exporter-dns.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-prometheus-exporter-dns.selectorsyncset.yaml.tmpl
@@ -28,6 +28,13 @@ objects:
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        labels:
+          config.openshift.io/inject-trusted-cabundle: 'true'
+        name: sre-dns-latency-exporter-trusted-ca-bundle
+        namespace: openshift-monitoring
+    - apiVersion: v1
       kind: ServiceAccount
       metadata:
         name: sre-dns-latency-exporter
@@ -80,6 +87,9 @@ objects:
               - mountPath: /monitor
                 name: monitor-volume
                 readOnly: true
+              - mountPath: /etc/pki/ca-trust/extracted/pem
+                name: trusted-ca-bundle
+                readOnly: true
               workingDir: /monitor
             dnsPolicy: ClusterFirst
             restartPolicy: Always
@@ -90,6 +100,13 @@ objects:
             - configMap:
                 name: sre-dns-latency-exporter-code
               name: monitor-volume
+            - configMap:
+                defaultMode: 420
+                items:
+                - key: ca-bundle.crt
+                  path: tls-ca-bundle.pem
+                name: sre-dns-latency-exporter-trusted-ca-bundle
+              name: trusted-ca-bundle
     - apiVersion: monitoring.coreos.com/v1
       kind: ServiceMonitor
       metadata:

--- a/resources/030_ca-configmap.yaml.tmpl
+++ b/resources/030_ca-configmap.yaml.tmpl
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: openshift-monitoring
+  name: $PREFIXED_NAME-trusted-ca-bundle
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"

--- a/resources/040_daemonset.yaml.tmpl
+++ b/resources/040_daemonset.yaml.tmpl
@@ -45,6 +45,9 @@ spec:
         - name: monitor-volume
           mountPath: /monitor
           readOnly: true
+        - mountPath: /etc/pki/ca-trust/extracted/pem
+          name: trusted-ca-bundle
+          readOnly: true
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       serviceAccountName: $SERVICEACCOUNT_NAME
@@ -54,3 +57,11 @@ spec:
       - name: monitor-volume
         configMap:
           name: $SOURCE_CONFIGMAP_NAME
+      - name: trusted-ca-bundle
+        configMap:
+          defaultMode: 420
+          items:
+            - key: ca-bundle.crt
+              path: tls-ca-bundle.pem
+          name: $PREFIXED_NAME-trusted-ca-bundle
+


### PR DESCRIPTION
### What type of PR is this?

Feature

### What this PR does / why we need it?

This PR adds a new `trusted-ca-bundle` ConfigMap for the exporter which will contain the system CA certs used to authenticate HTTPS connections. [0]

The ConfigMap contains the `config.openshift.io/inject-trusted-cabundle` label so that the user-supplied CA bundle is injected into it.

The ConfigMap is mounted into the container in the `/etc/pki/ca-trust/extracted/pem` location such that no other work is required to have the application use these CA for verifying server cert authenticity.

This is an approach which aligns with other cluster operators including the console and insights operators. 

[0] https://docs.openshift.com/container-platform/4.9/networking/configuring-a-custom-pki.html

### Which Jira/Github issue(s) this PR fixes?

[OSD-9058](https://issues.redhat.com/browse/OSD-9058)

### Special notes for your reviewer:

This change has been successfully tested on a cluster using a transparent forward proxy to ensure that it could successfully communicate to `*.amazonaws.com`.

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [X] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR
