### PR TITLE
OSD-9792 Move from python2 --> python3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ EXPORTER_NAME := dns-latency-exporter
 # currently unused
 EXPORTER_TYPE := daemonset
 
-# All of the source files which compose the monitor. 
+# All of the source files which compose the monitor.
 # Important note: No directory structure will be maintained
 SOURCEFILES ?= monitor/main.py monitor/start.sh
 
@@ -80,8 +80,8 @@ deploy/060_servicemonitor.yaml: resources/060_servicemonitor.yaml.tmpl
 
 .PHONY: generate-syncset
 generate-syncset:
-	docker pull quay.io/app-sre/python:2 2>/dev/null && docker tag quay.io/app-sre/python:2 python:2 || true; \
-	docker run --rm -v `pwd -P`:`pwd -P` python:2 /bin/sh -c "cd `pwd -P`; pip install pyyaml; scripts/generate_syncset.py -t ${SELECTOR_SYNC_SET_TEMPLATE_DIR} -y ${YAML_DIRECTORY} -d ${SELECTOR_SYNC_SET_DESTINATION} -r ${REPO_NAME}"
+	docker pull quay.io/app-sre/python:3 2>/dev/null && docker tag quay.io/app-sre/python:3 python:3 || true; \
+	docker run --rm -v `pwd -P`:`pwd -P` python:3 /bin/sh -c "cd `pwd -P`; pip3 install oyaml; scripts/generate_syncset.py -t ${SELECTOR_SYNC_SET_TEMPLATE_DIR} -y ${YAML_DIRECTORY} -d ${SELECTOR_SYNC_SET_DESTINATION} -r ${REPO_NAME}"
 
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -1,38 +1,18 @@
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+# DNS Metrics Exporter Overview
 
-- [Monitor Overview](#monitor-overview)
-- [Metrics](#metrics)
-- [Diagnosing alerts](#diagnosing-alerts)
-  - [DNSLatency200ms](#dnslatency200ms)
-
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
-
-<!-- Install doctoc with `npm install -g doctoc`  then `doctoc readme.md --github` -->
-
-# Monitor Overview
-
-Every minute, the dns test attempts to resolve redhat.com and times how long it takes.
-
-An alert is triggered if dns resolution for the last 5 minutes averages above 200ms.
+Every minute, the dns metrics exporter attempts to resolve redhat.com and times how long it takes.
 
 # Metrics
 
-Note: These amounts reset each time the test is installed or restarted.
+> Note: These amounts reset each time the workload is installed or restarted.
+
 - `dns_latency_milliseconds` - The time spent resolving dns
 - `dns_failure_failure_total` - The total number of dns errors encountered during tests
 
 ## Installation Process
 
-Installation of the exporter is a multi-step process. Step one is to use the provided Makefile to render various templates into OpenShift YAML manifests.
-
-### Rendering Templates with Make
-
-Use `make` to render the YAML manifests for the exporter.
-
-Once these have been created the collection of manifests can be applied in the usual fashion (such as `oc apply -f`).
+1. Use `make` to render the YAML manifests into the `deploy` directory
+2. Deploy the monitor to an OpenShift cluster with `oc apply -f deploy`
 
 ### Additional Make Targets
 
@@ -44,4 +24,6 @@ The Makefile includes three helpful targets:
 
 ### Prometheus Rules
 
-Rules are provided by the [openshift/managed-cluster-config](https://github.com/openshift/managed-cluster-config) repository.
+Rules are provided by the [openshift/managed-cluster-config](https://github.com/openshift/managed-cluster-config) repository. Currently there is only one:
+
+* [DNSErrors10MinSRE](https://github.com/openshift/managed-cluster-config/blob/bddd03fef32059e4ff020ba9f71161ccd8b71fb9/deploy/sre-prometheus/100-dns-latency.PrometheusRule.yaml) - indicates that there has been an increase in the `dns_failure_failure_total` counter over the last 10 minutes.

--- a/hack/00-osd-managed-prometheus-exporter-dns.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-prometheus-exporter-dns.selectorsyncset.yaml.tmpl
@@ -1,5 +1,11 @@
 apiVersion: v1
 kind: Template
+parameters:
+- name: IMAGE_TAG
+  required: true
+- name: REPO_NAME
+  value: managed-prometheus-exporter-dns
+  required: true
 metadata:
   name: selectorsyncset-template
 objects:
@@ -28,107 +34,6 @@ objects:
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1
-      kind: ConfigMap
-      metadata:
-        labels:
-          config.openshift.io/inject-trusted-cabundle: 'true'
-        name: sre-dns-latency-exporter-trusted-ca-bundle
-        namespace: openshift-monitoring
-    - apiVersion: v1
-      kind: ServiceAccount
-      metadata:
-        name: sre-dns-latency-exporter
-        namespace: openshift-monitoring
-    - apiVersion: apps/v1
-      kind: DaemonSet
-      metadata:
-        labels:
-          name: sre-dns-latency-exporter
-        name: sre-dns-latency-exporter
-        namespace: openshift-monitoring
-      spec:
-        selector:
-          matchLabels:
-            name: sre-dns-latency-exporter
-        template:
-          metadata:
-            labels:
-              name: sre-dns-latency-exporter
-            name: sre-dns-latency-exporter
-          spec:
-            containers:
-            - command:
-              - /bin/sh
-              - /monitor/start.sh
-              env:
-              - name: PYTHONPATH
-                value: /openshift-python/packages:/support/packages
-              image: quay.io/app-sre/managed-prometheus-exporter-base:latest
-              imagePullPolicy: IfNotPresent
-              livenessProbe:
-                failureThreshold: 2
-                httpGet:
-                  path: /
-                  port: 8080
-                initialDelaySeconds: 420
-                periodSeconds: 360
-                timeoutSeconds: 240
-              name: main
-              ports:
-              - containerPort: 8080
-                protocol: TCP
-              readinessProbe:
-                httpGet:
-                  path: /
-                  port: 8080
-                initialDelaySeconds: 3
-                timeoutSeconds: 240
-              volumeMounts:
-              - mountPath: /monitor
-                name: monitor-volume
-                readOnly: true
-              - mountPath: /etc/pki/ca-trust/extracted/pem
-                name: trusted-ca-bundle
-                readOnly: true
-              workingDir: /monitor
-            dnsPolicy: ClusterFirst
-            restartPolicy: Always
-            serviceAccountName: sre-dns-latency-exporter
-            tolerations:
-            - operator: Exists
-            volumes:
-            - configMap:
-                name: sre-dns-latency-exporter-code
-              name: monitor-volume
-            - configMap:
-                defaultMode: 420
-                items:
-                - key: ca-bundle.crt
-                  path: tls-ca-bundle.pem
-                name: sre-dns-latency-exporter-trusted-ca-bundle
-              name: trusted-ca-bundle
-    - apiVersion: monitoring.coreos.com/v1
-      kind: ServiceMonitor
-      metadata:
-        labels:
-          k8s-app: sre-dns-latency-exporter
-          name: sre-dns-latency-exporter
-        name: sre-dns-latency-exporter
-        namespace: openshift-monitoring
-      spec:
-        endpoints:
-        - honorLabels: true
-          interval: 2m
-          port: http-main
-          scheme: http
-          scrapeTimeout: 2m
-          targetPort: 0
-        jobLabel: sre-dns-latency-exporter
-        namespaceSelector: {}
-        selector:
-          matchLabels:
-            name: sre-dns-latency-exporter
-    - apiVersion: v1
       data:
         main.py: "#!/usr/bin/python\n\nimport time\nimport logging\nfrom prometheus_client
           import start_http_server, Counter, Gauge\nimport timeit\nimport traceback\n\nMONITOR_NAME
@@ -153,6 +58,94 @@ objects:
         name: sre-dns-latency-exporter-code
         namespace: openshift-monitoring
     - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        namespace: openshift-monitoring
+        name: sre-dns-latency-exporter-trusted-ca-bundle
+        labels:
+          config.openshift.io/inject-trusted-cabundle: 'true'
+    - apiVersion: apps/v1
+      kind: DaemonSet
+      metadata:
+        name: sre-dns-latency-exporter
+        namespace: openshift-monitoring
+        labels:
+          name: sre-dns-latency-exporter
+      spec:
+        selector:
+          matchLabels:
+            name: sre-dns-latency-exporter
+        template:
+          metadata:
+            name: sre-dns-latency-exporter
+            labels:
+              name: sre-dns-latency-exporter
+          spec:
+            containers:
+            - name: main
+              command:
+              - /bin/sh
+              - /monitor/start.sh
+              workingDir: /monitor
+              ports:
+              - containerPort: 8080
+                protocol: TCP
+              image: quay.io/app-sre/managed-prometheus-exporter-base:latest
+              env:
+              - name: PYTHONPATH
+                value: /openshift-python/packages:/support/packages
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                failureThreshold: 2
+                httpGet:
+                  path: /
+                  port: 8080
+                initialDelaySeconds: 420
+                periodSeconds: 360
+                timeoutSeconds: 240
+              readinessProbe:
+                httpGet:
+                  path: /
+                  port: 8080
+                initialDelaySeconds: 3
+                timeoutSeconds: 240
+              volumeMounts:
+              - name: monitor-volume
+                mountPath: /monitor
+                readOnly: true
+              - mountPath: /etc/pki/ca-trust/extracted/pem
+                name: trusted-ca-bundle
+                readOnly: true
+            dnsPolicy: ClusterFirst
+            restartPolicy: Always
+            serviceAccountName: sre-dns-latency-exporter
+            tolerations:
+            - operator: Exists
+            volumes:
+            - name: monitor-volume
+              configMap:
+                name: sre-dns-latency-exporter-code
+            - name: trusted-ca-bundle
+              configMap:
+                defaultMode: 420
+                items:
+                - key: ca-bundle.crt
+                  path: tls-ca-bundle.pem
+                name: sre-dns-latency-exporter-trusted-ca-bundle
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-dns-latency-exporter
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: edit
+      subjects:
+      - kind: ServiceAccount
+        name: sre-dns-latency-exporter
+        namespace: openshift-monitoring
+    - apiVersion: v1
       kind: Service
       metadata:
         labels:
@@ -169,22 +162,29 @@ objects:
           name: sre-dns-latency-exporter
         sessionAffinity: None
         type: ClusterIP
-    - apiVersion: rbac.authorization.k8s.io/v1
-      kind: RoleBinding
+    - apiVersion: v1
+      kind: ServiceAccount
       metadata:
         name: sre-dns-latency-exporter
         namespace: openshift-monitoring
-      roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: ClusterRole
-        name: edit
-      subjects:
-      - kind: ServiceAccount
+    - apiVersion: monitoring.coreos.com/v1
+      kind: ServiceMonitor
+      metadata:
         name: sre-dns-latency-exporter
         namespace: openshift-monitoring
-parameters:
-- name: IMAGE_TAG
-  required: true
-- name: REPO_NAME
-  required: true
-  value: managed-prometheus-exporter-dns
+        labels:
+          k8s-app: sre-dns-latency-exporter
+          name: sre-dns-latency-exporter
+      spec:
+        endpoints:
+        - honorLabels: true
+          interval: 2m
+          port: http-main
+          scheme: http
+          scrapeTimeout: 2m
+          targetPort: 0
+        jobLabel: sre-dns-latency-exporter
+        namespaceSelector: {}
+        selector:
+          matchLabels:
+            name: sre-dns-latency-exporter

--- a/resources/010_serviceaccount-rolebinding.yaml.tmpl
+++ b/resources/010_serviceaccount-rolebinding.yaml.tmpl
@@ -18,27 +18,3 @@ subjects:
 - kind: ServiceAccount
   name: $SERVICEACCOUNT_NAME
   namespace: openshift-monitoring
-#---
-# Currently not needed as this exporter does not use the init container
-#kind: ClusterRole
-#apiVersion: rbac.authorization.k8s.io/v1
-#metadata:
-#  name: sre-allow-read-machine-info
-#rules:
-#- apiGroups: ["machine.openshift.io"]
-#  resources: ["machines"]
-#  verbs: ["get", "list"]
-#---
-#kind: RoleBinding
-#apiVersion: rbac.authorization.k8s.io/v1
-#metadata:
-#  name: $SERVICEACCOUNT_NAME-read-machine-info
-#  namespace: openshift-machine-api
-#subjects:
-#- kind: ServiceAccount
-#  name: $SERVICEACCOUNT_NAME
-#  namespace: openshift-monitoring
-#roleRef:
-#  apiGroup: rbac.authorization.k8s.io
-#  kind: ClusterRole
-#  name: sre-allow-read-machine-info

--- a/scripts/generate_syncset.py
+++ b/scripts/generate_syncset.py
@@ -1,16 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # logic for sorted output: https://gist.github.com/oglops/c70fb69eef42d40bed06
 
-try:
-        # for python newer than 2.7
-    from collections import OrderedDict
-except ImportError:
-        # use backport from pypi
-    from ordereddict import OrderedDict
+from collections import OrderedDict
 
-import yaml
-
+import oyaml as yaml
 try:
     from yaml import CLoader as Loader, CDumper as Dumper
 except ImportError:
@@ -19,7 +13,6 @@ from yaml.representer import SafeRepresenter
 _mapping_tag = yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG
 
 import os
-import sys
 import argparse
 import copy
 
@@ -32,7 +25,7 @@ def dict_constructor(loader, node):
 
 def get_yaml_all(filename):
     with open(filename,'r') as input_file:
-        return list(yaml.load_all(input_file))
+        return list(yaml.safe_load_all(input_file))
 
 def get_yaml(filename):
     with open(filename,'r') as input_file:
@@ -55,8 +48,8 @@ def get_all_yaml_obj(file_paths):
         objects = get_yaml_all(file)
         for obj in objects:
             yaml_objs.append(obj)
-    yaml_objs = sorted(yaml_objs)
-    return yaml_objs
+    # Sort list of yamls by their kind
+    return sorted(yaml_objs, key=lambda d: d['kind'])
 
 def process_yamls(name, directory, obj):
     o = copy.deepcopy(obj)
@@ -65,7 +58,6 @@ def process_yamls(name, directory, obj):
     if len(yamls) == 0:
         return
 
-    yamls = sorted(yamls)
     for y in yamls:
         if 'patch' in y:
             if not 'patches' in o['spec']:
@@ -118,9 +110,6 @@ if __name__ == '__main__':
 
     Dumper.add_representer(str,
                         SafeRepresenter.represent_str)
-
-    Dumper.add_representer(unicode,
-                        SafeRepresenter.represent_unicode)
 
     with open(arguments.destination,'w') as outfile:
         yaml.dump(template_data, outfile, Dumper=Dumper, default_flow_style=False)


### PR DESCRIPTION
As part of the investigation to run this on HyperShift in [OSD-9792](https://issues.redhat.com//browse/OSD-9792), I noticed the syncset generation is still using a python2 image. Better late than never to move to python3!

I'm not too fluent with Python, but from what I found, the notion of sorting a dictionary is no longer implicit and must be explicitly set after moving from Python2 --> 3. I wasn't clear to me what the implicit ordering was, so the ordering of YAML files has changed in the generated syncset template when I explicitly sorted by `kind`.